### PR TITLE
Store slack tokens in memory only with user-friendly reconnect

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -82,9 +82,9 @@ func (s *SlackConnector) LoadUserLogin(ctx context.Context, login *bridgev2.User
 
 				msgText := `The server has forgotten your login for <strong>` + string(login.ID) + `</strong>, as requested, probably because it needed to restart.
 <br/><br/>
-I, the bot, left you a &#9757 command above &#9757 to help you log back in to this workspace a bit easier.
+I, the bot, left you a &#9757 command above &#9757 to help you log back in to this workspace easily.
 <br/><br/>
-If you want to reconnect to that Slack workspace, please copy the command and paste it into the chat with me here.`
+If you want to reconnect, please copy the command and paste it into the chat with me here.`
 
 				content := &event.MessageEventContent{
 					MsgType:       event.MsgText,

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -82,8 +82,10 @@ func (s *SlackConnector) LoadUserLogin(ctx context.Context, login *bridgev2.User
 				}
 
 				s.br.Bot.SendMessage(ctx, roomID, event.EventMessage, &event.Content{
-					Parsed: `Hey, seems like the server done did a restart for some reason. Please copy the commands above into the chat with me here
-because I'm actually a real dumb bot, and I cannot remember your Slack tokens!`,
+					Parsed: `Hey, seems like the server restarted for some reason.
+You elected to log in without persisting your access tokens for ` + fmt.Sprintf("%s on %s", userID, teamID) + `.
+I left you some commands above to help you log back in to this workspace a bit easier.
+Please copy those commands into the chat with me here; I'm actually a really dumb bot, and I can't see old messages.`,
 				}, nil)
 				return errors.New("could not find cached user tokens")
 			}

--- a/pkg/connector/internal/memtoken/memtoken.go
+++ b/pkg/connector/internal/memtoken/memtoken.go
@@ -1,0 +1,44 @@
+package memtoken
+
+import (
+	"sync"
+
+	"maunium.net/go/mautrix/bridgev2/networkid"
+)
+
+type MemToken struct {
+	mu        sync.RWMutex
+	TokenData map[networkid.UserLoginID]TokenData
+}
+
+type TokenData struct {
+	Token       string
+	CookieToken string
+}
+
+func NewMemToken() *MemToken {
+	return &MemToken{
+		TokenData: make(map[networkid.UserLoginID]TokenData),
+	}
+}
+
+func (mt *MemToken) Register(id networkid.UserLoginID, t, ct string) {
+	mt.mu.Lock()
+	defer mt.mu.Unlock()
+	mt.TokenData[id] = TokenData{
+		Token:       t,
+		CookieToken: ct,
+	}
+}
+
+func (mt *MemToken) Retrieve(id networkid.UserLoginID) (t, ct string, found bool) {
+	mt.mu.RLock()
+	defer mt.mu.RUnlock()
+
+	v, ok := mt.TokenData[id]
+	if !ok {
+		return "", "", false
+	}
+
+	return v.Token, v.CookieToken, true
+}

--- a/pkg/connector/login-cookie.go
+++ b/pkg/connector/login-cookie.go
@@ -154,8 +154,6 @@ func (s *SlackTokenLogin) SubmitCookies(ctx context.Context, input map[string]st
 
 	loginID := slackid.MakeUserLoginID(info.Team.ID, info.Self.ID)
 
-	successInstructions := fmt.Sprintf("Successfully logged into %s as %s", info.Team.Name, info.Self.Profile.Email)
-
 	if s.Ephemeral {
 		mt.Register(loginID, token, cookieToken)
 
@@ -221,7 +219,7 @@ Simply copy the following text into a message with me:
 	return &bridgev2.LoginStep{
 		Type:         bridgev2.LoginStepTypeComplete,
 		StepID:       LoginStepIDComplete,
-		Instructions: successInstructions,
+		Instructions: fmt.Sprintf("Successfully logged into %s as %s", info.Team.Name, info.Self.Profile.Email),
 		CompleteParams: &bridgev2.LoginCompleteParams{
 			UserLoginID: ul.ID,
 			UserLogin:   ul,

--- a/pkg/connector/login-cookie.go
+++ b/pkg/connector/login-cookie.go
@@ -169,7 +169,7 @@ func (s *SlackTokenLogin) SubmitCookies(ctx context.Context, input map[string]st
 If the server happens to reboot for whatever reason, you'll need to log in again to keep syncing Slack messages to your space.
 <br/><br/>
 
-When that happens, I, the bot, will DM you, asking for your token info for ` + info.Team.Name +
+When that happens, I, the bot, will message you here, asking for your token info for ` + info.Team.Name +
 			` again.
 <br/><br/>
 Simply copy the following text into a message with me:

--- a/pkg/connector/memtoken.go
+++ b/pkg/connector/memtoken.go
@@ -1,0 +1,10 @@
+package connector
+
+import (
+	"go.mau.fi/mautrix-slack/pkg/connector/internal/memtoken"
+	"maunium.net/go/mautrix/bridgev2/networkid"
+)
+
+var mt = memtoken.MemToken{
+	TokenData: make(map[networkid.UserLoginID]memtoken.TokenData),
+}


### PR DESCRIPTION
If a user elects to log in to the bridge with `login token`, the provided tokens will be stored in the bridge DB. If the user prefers not to have the login creds persisted on the server, introduce a new login method, `login token-forget`. In this mode, the token is stored in memory only. When the server resets, the token will be lost.

To assist with re-authenticating after a server reset, after login, the bot sends a (hidden) copyable command `login token-forget xyz... abc...` that will re-login with the exact same creds. That command can be copied directly into the same chat to reach the same login state as prior to the server reset. It's recommended this mode be used with *encryption enabled* in the slackbot chat.

Essentially the creds are stored in the Matrix DB instead, which should be encrypted, rather than the bridge DB. The user needs to do some occasional manual work to give the matrix-stored creds back to the bot after each reset.

`login token-forget`:
![image](https://github.com/user-attachments/assets/d1ec7e3e-e14c-4d47-9ea5-43ab867e44e8)

Collapsible, copyable reconnect command:
![image](https://github.com/user-attachments/assets/fa81eacf-1d3c-4da5-98d2-aee411165e12)


Upon bridge server reset, automatic re-login request:
![image](https://github.com/user-attachments/assets/601e00de-aa3d-47f6-852d-91c1f4ae854b)

