### PR TITLE
Fix thread order by preserving message order

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -106,7 +106,12 @@ func (s *SlackClient) FetchMessages(ctx context.Context, params bridgev2.FetchMe
 			maxMsgID = msg.Timestamp
 		}
 	}
-	slices.Reverse(convertedMessages)
+
+	// Reverse converted messages order for non-thread messages.
+	if params.ThreadRoot == "" {
+		slices.Reverse(convertedMessages)
+	}
+
 	lastRead := s.getLastReadCache(channelID)
 	return &bridgev2.FetchMessagesResponse{
 		Messages: convertedMessages,


### PR DESCRIPTION
Prevent reversing order for messages belonging to a thread; the order will be preserved as expected.